### PR TITLE
fix when enter detail page app crashed (because the old version kotli…

### DIFF
--- a/buildSrc/src/main/kotlin/Kotlinx.kt
+++ b/buildSrc/src/main/kotlin/Kotlinx.kt
@@ -1,4 +1,4 @@
 object Kotlinx {
-    private const val kotlinxDatetimeVersion = "0.1.1"
+    private const val kotlinxDatetimeVersion = "0.2.1"
     const val datetime = "org.jetbrains.kotlinx:kotlinx-datetime:${kotlinxDatetimeVersion}"
 }


### PR DESCRIPTION
…nx-datetime is not Compatible with kotlin 1.5.x)